### PR TITLE
Add "*" support in URLs to allow/deny/redirect

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -42,8 +42,11 @@ namespace LocalDns
             Console.WriteLine("LocalDNS 1.2 By Exelix11");
             Console.WriteLine("https://github.com/exelix11/LocalDns");
             Console.WriteLine("");
-            Dictionary<string, DnsSettings> rules = null;
+
+            Dictionary<string, DnsSettings> dicRules = null;
+            List<KeyValuePair<string, DnsSettings>> regRules = null;
             DnsCore Dns = new LocalDns.DnsCore();
+
             #region parseArgs
             bool DownloadRules = false; //Uhhh bad code :(
             if (args.Length != 0)
@@ -67,7 +70,7 @@ namespace LocalDns
                                 if (DownloadRules) break;
                                 if (File.Exists(args[i + 1]))
                                 {
-                                    rules = ParseRules(args[i + 1]);
+                                    ParseRules(args[i + 1], out dicRules, out regRules);
                                 }
                                 else
                                 {
@@ -87,7 +90,7 @@ namespace LocalDns
                                     {
                                         Dns.LocalHostIp = ipAddr;
                                     }
-                                    else Console.WriteLine($"Warning: Couldn't parse '{ipStr}' as an IP address");
+                                    else Console.WriteLine("Warning: Couldn't parse '{ipStr}' as an IP address");
                                 }
                                 break;
                         }
@@ -110,13 +113,13 @@ namespace LocalDns
                 WebResponse response = http.GetResponse();
                 StreamReader sr = new StreamReader(response.GetResponseStream());
                 string content = sr.ReadToEnd();
-                rules = ParseRules(content, false);
+                ParseRules(content, out dicRules, out regRules, false);
             }
-            else if (rules == null)
+            else if (dicRules == null)
             {
                 if (File.Exists("Rules.txt"))
                 {
-                    rules = ParseRules("Rules.txt");
+                    ParseRules("Rules.txt", out dicRules, out regRules);
                 }
                 else
                 {
@@ -130,7 +133,9 @@ namespace LocalDns
                 Console.WriteLine("BlockNotInRules: " + Dns.DenyNotInRules.ToString());
                 Console.WriteLine("localhost: " + Dns.LocalHostIp.ToString());
             }
-            Dns.rules = rules;
+
+            Dns.dicRules = dicRules;
+            Dns.regRules = regRules;
             Dns.FireEvents = true;
             Dns.ResolvedIp += ResolvedIp;
             Dns.ConnectionRequest += ConnectionRequest;
@@ -170,9 +175,11 @@ namespace LocalDns
             Console.WriteLine("_____________________________________________");
         }
 
-        static Dictionary<string, DnsSettings> ParseRules(string Filename, bool IsFilename = true)
+        static void ParseRules(string Filename, out Dictionary<string, DnsSettings> DicRules, out List<KeyValuePair<string, DnsSettings>> StarRules, bool IsFilename = true)
         {
-            Dictionary<string, DnsSettings> res = new Dictionary<string, DnsSettings>();
+            DicRules = new Dictionary<string,DnsSettings>();
+            StarRules = new List<KeyValuePair<string, DnsSettings>>();
+
             string[] rules = IsFilename ? File.ReadAllLines(Filename) : Filename.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.None);
             foreach (string s in rules)
             {
@@ -194,17 +201,29 @@ namespace LocalDns
                     default:
                         throw new Exception("Can't parse rules !");
                 }
-                res.Add(split[0].Trim(), dns);
-                res.Add("www." + split[0].Trim(), dns);
+
+                string domain = split[0].Trim();
+                if (domain.Contains("*"))
+                {
+                    domain = domain.Replace(".", "\\.");
+                    domain = domain.Replace("*", ".*");
+                    StarRules.Add(new KeyValuePair<string, DnsSettings>(domain, dns));
+                }
+                else
+                {
+                    DicRules.Add(domain, dns);
+                    DicRules.Add("www." + domain, dns);
+                }
             }
-            Console.WriteLine(res.Count.ToString() + " rules loaded");
+
+            Console.WriteLine(DicRules.Count.ToString() + " dictionary rules and " + StarRules.Count.ToString() + " star rules loaded");
             if (System.Diagnostics.Debugger.IsAttached)
             {
                 List<string[]> ToPad = new List<string[]>();
-                foreach (string s in res.Keys.ToArray()) ToPad.Add( new string[] { s, res[s].Mode.ToString(), res[s].Address == null ? "" : res[s].Address });
+                foreach (string s in DicRules.Keys.ToArray()) ToPad.Add(new string[] { s, DicRules[s].Mode.ToString(), DicRules[s].Address == null ? "" : DicRules[s].Address });
+                foreach (KeyValuePair<string, DnsSettings> rule in StarRules) ToPad.Add(new string[] { rule.Key, rule.Value.Mode.ToString(), rule.Value.Address == null ? "" : rule.Value.Address });
                 Console.WriteLine(ConsoleUtility.PadElementsInLines(ToPad, 5));
             }
-            return res;
         }
 
         static void PrintHelp()

--- a/Program.cs
+++ b/Program.cs
@@ -205,7 +205,16 @@ namespace LocalDns
                 string domain = split[0].Trim();
                 if (domain.Contains("*"))
                 {
+                    // Escape all possible URI characters conflicting with Regex
                     domain = domain.Replace(".", "\\.");
+                    domain = domain.Replace("$", "\\$");
+                    domain = domain.Replace("[", "\\[");
+                    domain = domain.Replace("]", "\\]");
+                    domain = domain.Replace("(", "\\(");
+                    domain = domain.Replace(")", "\\)");
+                    domain = domain.Replace("+", "\\+");
+                    domain = domain.Replace("?", "\\?");
+                    // Replace "*" characters with ".*" which means any number of any character for Regexp
                     domain = domain.Replace("*", ".*");
                     StarRules.Add(new KeyValuePair<string, DnsSettings>(domain, dns));
                 }

--- a/Rules.txt
+++ b/Rules.txt
@@ -1,5 +1,10 @@
 ;This is the rules file, each line must contain only one rule in this format:
 ;*url*,*action: Deny|Allow|Redirect*,[Optional RedirectUrl]
+;
+;*url* can contain '*' characters which means that at '*' positions, there can be any number of other characters.
+;When *url* with '*' is in conflict with a *url* without '*', the rule from *url* without '*' has priority.
+;When multiple *url* with '*' are conflicting, the first rule with *url* with '*' has priority.
+;
 ;Examples:
 ;Example.com,Deny
 ;   This will redirect every Examples.com query to the Localhost address (the default for localhost is "NXDOMAIN" which sends a domain not found error, you can use a custom one from the command line args)
@@ -7,6 +12,15 @@
 ;   This will redirect Example.com to Example2.com, you can also use an ip address
 ;Example.com,Allow
 ;   This will resolve Example.com to its real address, use this with BlockNotInList set to true, so every other site will be redirected to Localhost
+;*Example*,Deny
+;Example.com,Allow
+;   This will resolve Example.com to its real address and Example.net to the Localhost address
+;Example.*,Allow
+;*Example*,Deny
+;   This will resolve Example.com or Example.net to its real address and test.Example.com to the Localhost address
+;*Example*,Deny
+;Example.*,Allow
+;   This will redirect Example.com, Example.net and test.Example.com to the Localhost address
 
 ;Wii U/3DS update servers
 ;------------------------

--- a/Rules.txt
+++ b/Rules.txt
@@ -32,7 +32,9 @@ aqua.hac.lp1.d4c.nintendo.net,Deny
 sun.hac.lp1.d4c.nintendo.net,Deny
 superfly.hac.lp1.d4c.nintendo.net,Deny
 beach.hac.lp1.eshop.nintendo.net,Deny
+aauth-lp1.ndas.srv.nintendo.net,Deny
 dauth-lp1.ndas.srv.nintendo.net,Deny
+api.accounts.nintendo.com,Deny
 ctest.cdn.nintendo.net,Redirect,95.216.149.205
 conntest.nintendowifi.net,Redirect,95.216.149.205
 *.nintendo.net,Deny

--- a/Rules.txt
+++ b/Rules.txt
@@ -8,7 +8,7 @@
 ;Example.com,Allow
 ;   This will resolve Example.com to its real address, use this with BlockNotInList set to true, so every other site will be redirected to Localhost
 
-;Wii u/3DS update servers
+;Wii U/3DS update servers
 ;------------------------
 nus.c.shop.nintendowifi.net,Deny
 nus.cdn.c.shop.nintendowifi.net,Deny
@@ -27,7 +27,25 @@ a184-50-229-137.deploy.static.akamaitechnologies.com,Deny
 c.shop.nintendowifi.net,Deny
 cbvc.nintendo.net,Deny
 
-;switch
+;PS3
+;---
+es.np.adproxy.ndmdhs.com,Deny
+nsx.sec.np.dl.playstation.net,Deny
+xmb-e.dl.playstation.net,Deny
+auth.np.ac.playstation.net,Deny
+*.np.stun.playstation.net,Deny
+ena.net.playstation.net,Deny
+*.ena.net.playstation.net,Deny
+*.ps3.update.playstation.net,Deny
+service.playstation.net,Deny
+*.service.playstation.net,Deny
+creepo.ww.hl.playstation.net,Deny
+*.creepo.ww.hl.playstation.net,Deny
+*.np.community.playstation.net,Deny 
+np.community.playstation.net,Deny
+manuals.playstation.net,Deny
+
+;Switch
 ;------
 ; - wifi connection -
 ctest.cdn.nintendo.net,Redirect,95.216.149.205
@@ -36,15 +54,18 @@ conntest.nintendowifi.net,Redirect,95.216.149.205
 aauth-lp1.ndas.srv.nintendo.net,Deny
 dauth-lp1.ndas.srv.nintendo.net,Deny
 api.accounts.nintendo.com,Deny
-; - games update - replace "Deny" by "Allow" to receive game update (BAN RISK!)
+; - game update - comment those as well as "*.nintendo.net" to receive game update (BAN RISK!)
+aqua.hac.lp1.d4c.nintendo.net,Deny
 atum.hac.lp1.d4c.nintendo.net,Deny
 superfly.hac.lp1.d4c.nintendo.net,Deny
 ; - system update -
 sun.hac.lp1.d4c.nintendo.net,Deny
 beach.hac.lp1.eshop.nintendo.net,Deny
-; - unknown -
+; - unknown - locked just in case
+tagaya.hac.lp1.eshop.nintendo.net,Deny
+receive-lp1.dg.srv.nintendo.net,Deny
+receive-lp1.er.srv.nintendo.net,Deny
 app-*.lp1.npns.srv.nintendo.net,Deny
-aqua.hac.lp1.d4c.nintendo.net,Deny
 ; - others -
 *.nintendo.net,Deny
 *.nintendo.com,Deny

--- a/Rules.txt
+++ b/Rules.txt
@@ -9,6 +9,7 @@
 ;   This will resolve Example.com to its real address, use this with BlockNotInList set to true, so every other site will be redirected to Localhost
 
 ;Wii u/3DS update servers
+;------------------------
 nus.c.shop.nintendowifi.net,Deny
 nus.cdn.c.shop.nintendowifi.net,Deny
 nus.cdn.shop.wii.com,Deny
@@ -27,16 +28,24 @@ c.shop.nintendowifi.net,Deny
 cbvc.nintendo.net,Deny
 
 ;switch
-atum.hac.lp1.d4c.nintendo.net,Deny
-aqua.hac.lp1.d4c.nintendo.net,Deny
-sun.hac.lp1.d4c.nintendo.net,Deny
-superfly.hac.lp1.d4c.nintendo.net,Deny
-beach.hac.lp1.eshop.nintendo.net,Deny
+;------
+; - wifi connection -
+ctest.cdn.nintendo.net,Redirect,95.216.149.205
+conntest.nintendowifi.net,Redirect,95.216.149.205
+; - piracy checks -
 aauth-lp1.ndas.srv.nintendo.net,Deny
 dauth-lp1.ndas.srv.nintendo.net,Deny
 api.accounts.nintendo.com,Deny
-ctest.cdn.nintendo.net,Redirect,95.216.149.205
-conntest.nintendowifi.net,Redirect,95.216.149.205
+; - games update - replace "Deny" by "Allow" to receive game update (BAN RISK!)
+atum.hac.lp1.d4c.nintendo.net,Deny
+superfly.hac.lp1.d4c.nintendo.net,Deny
+; - system update -
+sun.hac.lp1.d4c.nintendo.net,Deny
+beach.hac.lp1.eshop.nintendo.net,Deny
+; - unknown -
+app-*.lp1.npns.srv.nintendo.net,Deny
+aqua.hac.lp1.d4c.nintendo.net,Deny
+; - others -
 *.nintendo.net,Deny
 *.nintendo.com,Deny
 *.nintendo.co.uk,Deny

--- a/Rules.txt
+++ b/Rules.txt
@@ -27,8 +27,12 @@ c.shop.nintendowifi.net,Deny
 cbvc.nintendo.net,Deny
 
 ;switch
+atum.hac.lp1.d4c.nintendo.net,Deny
+aqua.hac.lp1.d4c.nintendo.net,Deny
 sun.hac.lp1.d4c.nintendo.net,Deny
+superfly.hac.lp1.d4c.nintendo.net,Deny
 beach.hac.lp1.eshop.nintendo.net,Deny
+dauth-lp1.ndas.srv.nintendo.net,Deny
 ctest.cdn.nintendo.net,Redirect,95.216.149.205
 conntest.nintendowifi.net,Redirect,95.216.149.205
 *.nintendo.net,Deny

--- a/Rules.txt
+++ b/Rules.txt
@@ -29,3 +29,36 @@ cbvc.nintendo.net,Deny
 ;switch
 sun.hac.lp1.d4c.nintendo.net,Deny
 beach.hac.lp1.eshop.nintendo.net,Deny
+ctest.cdn.nintendo.net,Redirect,95.216.149.205
+conntest.nintendowifi.net,Redirect,95.216.149.205
+*.nintendo.net,Deny
+*.nintendo.com,Deny
+*.nintendo.co.uk,Deny
+*.nintendo-europe.com,Deny
+*.nintendo.jp,Deny
+*.nintendo.co.jp,Deny
+*.nintendo.es,Deny
+*.nintendo.co.kr,Deny
+*.nintendo.tw,Deny
+*.nintendo.com.hk,Deny
+*.nintendo.com.au,Deny
+*.nintendo.co.nz,Deny
+*.nintendo.at,Deny
+*.nintendo.be,Deny
+*.nintendods.cz,Deny
+*.nintendo.dk,Deny
+*.nintendo.de,Deny
+*.nintendo.fi,Deny
+*.nintendo.fr,Deny
+*.nintendo.gr,Deny
+*.nintendo.hu,Deny
+*.nintendo.it,Deny
+*.nintendo.nl,Deny
+*.nintendo.no,Deny
+*.nintendo.pt,Deny
+*.nintendo.ru,Deny
+*.nintendo.co.za ,Deny
+*.nintendo.se,Deny
+*.nintendo.ch ,Deny
+*.google-analytics.com,Deny
+*.googletagmanager.com,Deny


### PR DESCRIPTION
This change add the support of "\*" in URLs: "\*" URLs are stored in another list (not the dictionary) and are transformed to be ready for Regex.
The previous dictionary implementation is kept to manage "full" URLs. Then, if an URL doesn't match anything in the dictionary, it is compared with all stored Regex ready strings.
The file "Rules.txt" has been updated to match 90DNS domain list (https://gitlab.com/ao/90dns) and this update uses the latest changes.
